### PR TITLE
Add Unity automation pipeline tools and scripts

### DIFF
--- a/.github/workflows/unity-pipeline.yml
+++ b/.github/workflows/unity-pipeline.yml
@@ -1,0 +1,48 @@
+name: Unity MCP Pipeline
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - UnityMcpBridge/**
+      - scripts/try_pipeline.sh
+      - .github/workflows/unity-pipeline.yml
+      - validation.json
+  pull_request:
+    paths:
+      - UnityMcpBridge/**
+      - scripts/try_pipeline.sh
+      - .github/workflows/unity-pipeline.yml
+      - validation.json
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        working-directory: UnityMcpBridge/UnityMcpServer~/src
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Execute MCP pipeline (Unity project probe/compile/tests)
+        env:
+          UNITY_MCP_SKIP_STARTUP_CONNECT: "1"
+        run: |
+          scripts/try_pipeline.sh "$(pwd)/TestProjects/UnityMCPTests" "$(pwd)/logs"
+
+      - name: Upload pipeline logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-pipeline-logs
+          path: logs
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -350,3 +350,95 @@ MIT License. See [LICENSE](LICENSE) file.
     <img src="logo.png" alt="Coplay Logo" width="100%">
   </a>
 </p>
+
+---
+
+## 🧪 Pipeline 使用指南
+
+MCP for Unity 现已内置统一的自动化编译/测试管线。你可以使用仓库提供的脚本在本地快速验证：
+
+```bash
+# 以当前目录作为 Unity 工程根目录运行整套校验
+scripts/try_pipeline.sh /path/to/UnityProject
+
+# 可选：指定日志目录
+scripts/try_pipeline.sh /path/to/UnityProject /path/to/logs
+```
+
+脚本会依次调用以下工具（均返回统一结构 `{ ok, exitCode, data?, errors? }`）并将 JSON 结果写入 `logs/*.json`；
+一旦任一步骤失败，脚本会以非零状态退出，方便在 CI 中作为守门人。
+
+1. `unity_project_probe`
+2. `roslyn_check`
+3. `unity_compile`
+4. `unity_run_tests`（EditMode 与 PlayMode）
+5. `unity_build_il2cpp`（可选）
+
+同时，仓库根目录新增的 `validation.json` 描述了推荐的通过阈值：
+
+```json
+{
+  "compile": {"maxErrors": 0},
+  "tests": {"editMinPassRate": 0.95, "playMinPassRate": 0.90},
+  "il2cpp": {"required": false}
+}
+```
+
+---
+
+## 🧰 工具契约（JSON）
+
+MCP Server 中的核心工具契约如下，所有响应均遵循 `{ ok:boolean, exitCode:number, data?:object, errors?:[...] }`：
+
+### `unity_project_probe`
+
+**入参**：`{ projectPath: string }`
+
+**出参（data）示例**：
+
+```json
+{
+  "unityVersion": "6000.0.0f1",
+  "apiCompatibilityLevel": "NET_Standard_2_1",
+  "scriptingBackendPerPlatform": {"Standalone": "Mono", "Android": "IL2CPP"},
+  "packages": [{"name": "com.unity.test-framework", "version": "1.4.5"}],
+  "editorApplicationPath": "/Applications/Unity/Unity.app",
+  "roslynCompilerPath": ".../Tools/Roslyn/csc",
+  "managedAssemblySearchPaths": [".../Managed", ".../Managed/UnityEngine", ...]
+}
+```
+
+### `roslyn_check`
+
+**入参**：`{ projectPath: string, glob?: string, langVersion?: "9.0" }`
+
+**出参（data）**：`{ "checked": number, "errors": [{code,file,line,message}, ...] }`
+
+### `unity_compile`
+
+**入参**：`{ projectPath: string, logPath?: string }`
+
+**出参（data）**：`{ "errors": [...], "warnings": [...], "rawLogPath": ".../Editor.log" }`
+
+### `unity_run_tests`
+
+**入参**：`{ projectPath: string, platform: "EditMode" | "PlayMode", resultsPath?: string }`
+
+**出参（data）**：
+
+```json
+{
+  "passed": 42,
+  "failed": 0,
+  "durationSec": 12.34,
+  "failures": [{"testName": "Namespace.Test", "message": "Assertion", "stacktrace": "..."}],
+  "resultsPath": "logs/editmode-results.xml",
+  "logPath": ".../Editor.log"
+}
+```
+
+### `unity_build_il2cpp`
+
+**入参**：`{ projectPath: string, target: string, outputDir?: string }`
+
+若项目未配置自定义 BuildScript，工具会返回结构化错误 `unity_build_il2cpp_not_implemented`，方便上层决定是否忽略。

--- a/UnityMcpBridge/Editor/AIBuild.cs
+++ b/UnityMcpBridge/Editor/AIBuild.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+
+namespace MCPForUnity.Editor
+{
+    /// <summary>
+    /// Helper entry points invoked by the MCP automation layer. These methods are intentionally
+    /// lightweight so they can be triggered either from the running editor instance or via
+    /// Unity's batchmode invocation using -executeMethod.
+    /// </summary>
+    public static class AIBuild
+    {
+        /// <summary>
+        /// Write a UTF-8 JSON payload to the provided path, creating parent directories if
+        /// necessary. Returns the absolute path that was written.
+        /// </summary>
+        public static string WriteJson(string path, string json)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Path cannot be null or empty", nameof(path));
+            }
+
+            string directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(path, json ?? "{}", new UTF8Encoding(false));
+            return Path.GetFullPath(path);
+        }
+
+        /// <summary>
+        /// Trigger a domain refresh/compilation and wait until the editor is done compiling.
+        /// </summary>
+        public static void VerifyCompile()
+        {
+            AssetDatabase.Refresh();
+            var start = DateTime.UtcNow;
+            while (CompilationPipeline.isCompiling)
+            {
+                Thread.Sleep(100);
+                if ((DateTime.UtcNow - start).TotalMinutes > 10)
+                {
+                    throw new TimeoutException("Compilation did not complete within 10 minutes.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute edit mode or play mode tests and ensure an NUnit compatible XML file is written.
+        /// The method blocks until test execution completes.
+        /// </summary>
+        public static string RunTests(string testMode, string resultsPath = "Logs/results.xml")
+        {
+            if (string.IsNullOrWhiteSpace(testMode))
+            {
+                throw new ArgumentException("testMode is required", nameof(testMode));
+            }
+
+            string resolvedPath = ResolveResultsPath(resultsPath);
+            EnsureDirectory(resolvedPath);
+
+            var api = ScriptableObject.CreateInstance<TestRunnerApi>();
+            try
+            {
+                var filter = new Filter
+                {
+                    testMode = string.Equals(testMode, "PlayMode", StringComparison.OrdinalIgnoreCase)
+                        ? TestMode.PlayMode
+                        : TestMode.EditMode
+                };
+
+                using var completion = new ManualResetEvent(false);
+                ITestResultAdaptor finalResult = null;
+                api.RegisterCallbacks(new TestCallbacks(resolvedPath, r =>
+                {
+                    finalResult = r;
+                    completion.Set();
+                }));
+
+                var settings = new ExecutionSettings
+                {
+                    filters = new[] { filter },
+                    runSynchronously = true
+                };
+
+                api.Execute(settings);
+
+                if (!completion.WaitOne(TimeSpan.FromMinutes(30)))
+                {
+                    throw new TimeoutException("Test execution timed out after 30 minutes.");
+                }
+
+                if (finalResult == null)
+                {
+                    throw new InvalidOperationException("Test execution did not produce a result.");
+                }
+
+                // The callback already wrote the XML; return the resolved path for convenience.
+                return resolvedPath;
+            }
+            finally
+            {
+                ScriptableObject.DestroyImmediate(api);
+            }
+        }
+
+        private static string ResolveResultsPath(string path)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return Path.GetFullPath(path);
+            }
+
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return Path.GetFullPath(Path.Combine(projectRoot, path));
+        }
+
+        private static void EnsureDirectory(string filePath)
+        {
+            string directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+        }
+
+        private sealed class TestCallbacks : ICallbacks
+        {
+            private readonly string _resultsPath;
+            private readonly Action<ITestResultAdaptor> _onComplete;
+
+            public TestCallbacks(string resultsPath, Action<ITestResultAdaptor> onComplete)
+            {
+                _resultsPath = resultsPath;
+                _onComplete = onComplete;
+            }
+
+            public void RunStarted(ITestAdaptor testsToRun)
+            {
+            }
+
+            public void RunFinished(ITestResultAdaptor result)
+            {
+                try
+                {
+                    WriteNUnitXml(_resultsPath, result);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[AIBuild] Failed to write test results XML: {ex.Message}\n{ex.StackTrace}");
+                }
+                finally
+                {
+                    _onComplete?.Invoke(result);
+                }
+            }
+
+            public void TestStarted(ITestAdaptor test)
+            {
+            }
+
+            public void TestFinished(ITestResultAdaptor result)
+            {
+            }
+
+            private static void WriteNUnitXml(string path, ITestResultAdaptor result)
+            {
+                var summary = new NUnitSummary(result);
+                var builder = new System.Xml.Linq.XDocument(
+                    new System.Xml.Linq.XDeclaration("1.0", "utf-8", "yes"),
+                    new System.Xml.Linq.XElement(
+                        "test-run",
+                        new System.Xml.Linq.XAttribute("id", "0"),
+                        new System.Xml.Linq.XAttribute("name", Application.productName ?? "Unity Project"),
+                        new System.Xml.Linq.XAttribute("result", summary.Result),
+                        new System.Xml.Linq.XAttribute("total", summary.Total),
+                        new System.Xml.Linq.XAttribute("passed", summary.Passed),
+                        new System.Xml.Linq.XAttribute("failed", summary.Failed),
+                        new System.Xml.Linq.XAttribute("skipped", summary.Skipped),
+                        new System.Xml.Linq.XAttribute("duration", summary.DurationSeconds.ToString("F3")),
+                        new System.Xml.Linq.XElement(
+                            "test-suite",
+                            new System.Xml.Linq.XAttribute("type", "Assembly"),
+                            new System.Xml.Linq.XAttribute("name", result.Name ?? "Tests"),
+                            new System.Xml.Linq.XAttribute("result", summary.Result),
+                            BuildTestCaseElements(result)
+                        )
+                    )
+                );
+
+                using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+                builder.Save(stream);
+            }
+
+            private static IEnumerable<System.Xml.Linq.XElement> BuildTestCaseElements(ITestResultAdaptor root)
+            {
+                foreach (var child in root.Children ?? Array.Empty<ITestResultAdaptor>())
+                {
+                    if (child.HasChildren)
+                    {
+                        yield return new System.Xml.Linq.XElement(
+                            "test-suite",
+                            new System.Xml.Linq.XAttribute("type", child.Test?.HasChildren == true ? "Suite" : "Test"),
+                            new System.Xml.Linq.XAttribute("name", child.Name ?? "Unnamed"),
+                            new System.Xml.Linq.XAttribute("result", child.ResultState?.Status.ToString() ?? "Unknown"),
+                            BuildTestCaseElements(child)
+                        );
+                    }
+                    else
+                    {
+                        yield return new System.Xml.Linq.XElement(
+                            "test-case",
+                            new System.Xml.Linq.XAttribute("name", child.Name ?? "Unnamed"),
+                            new System.Xml.Linq.XAttribute("fullname", child.FullName ?? child.Name ?? "Unnamed"),
+                            new System.Xml.Linq.XAttribute("result", child.ResultState?.Status.ToString() ?? "Unknown"),
+                            new System.Xml.Linq.XAttribute("duration", child.Duration.ToString("F3")),
+                            child.ResultState?.Status == TestStatus.Failed && !string.IsNullOrEmpty(child.Message)
+                                ? new System.Xml.Linq.XElement(
+                                    "failure",
+                                    new System.Xml.Linq.XElement("message", child.Message ?? string.Empty),
+                                    new System.Xml.Linq.XElement("stack-trace", child.StackTrace ?? string.Empty)
+                                )
+                                : null
+                        );
+                    }
+                }
+            }
+        }
+
+        private sealed class NUnitSummary
+        {
+            public NUnitSummary(ITestResultAdaptor result)
+            {
+                Total = result?.TestCaseCount ?? 0;
+                Passed = result?.PassCount ?? 0;
+                Failed = result?.FailCount ?? 0;
+                Skipped = result?.SkipCount ?? 0;
+                DurationSeconds = result?.Duration ?? 0.0;
+                Result = result?.ResultState?.Status.ToString() ?? "Unknown";
+            }
+
+            public int Total { get; }
+            public int Passed { get; }
+            public int Failed { get; }
+            public int Skipped { get; }
+            public double DurationSeconds { get; }
+            public string Result { get; }
+        }
+    }
+}

--- a/UnityMcpBridge/Editor/AIBuild.cs
+++ b/UnityMcpBridge/Editor/AIBuild.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using UnityEditor;
-using UnityEditor.Compilation;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
 
@@ -46,7 +45,7 @@ namespace MCPForUnity.Editor
         {
             AssetDatabase.Refresh();
             var start = DateTime.UtcNow;
-            while (CompilationPipeline.isCompiling)
+            while (EditorApplication.isCompiling)
             {
                 Thread.Sleep(100);
                 if ((DateTime.UtcNow - start).TotalMinutes > 10)
@@ -242,12 +241,25 @@ namespace MCPForUnity.Editor
         {
             public NUnitSummary(ITestResultAdaptor result)
             {
-                Total = result?.TestCaseCount ?? 0;
-                Passed = result?.PassCount ?? 0;
-                Failed = result?.FailCount ?? 0;
-                Skipped = result?.SkipCount ?? 0;
-                DurationSeconds = result?.Duration ?? 0.0;
-                Result = result?.ResultState?.Status.ToString() ?? "Unknown";
+                if (result != null)
+                {
+                    CountResults(result, out int total, out int passed, out int failed, out int skipped);
+                    Total = total;
+                    Passed = passed;
+                    Failed = failed;
+                    Skipped = skipped;
+                    DurationSeconds = result.Duration;
+                    Result = result.ResultState?.Status.ToString() ?? "Unknown";
+                }
+                else
+                {
+                    Total = 0;
+                    Passed = 0;
+                    Failed = 0;
+                    Skipped = 0;
+                    DurationSeconds = 0.0;
+                    Result = "Unknown";
+                }
             }
 
             public int Total { get; }
@@ -256,6 +268,56 @@ namespace MCPForUnity.Editor
             public int Skipped { get; }
             public double DurationSeconds { get; }
             public string Result { get; }
+
+            private static void CountResults(ITestResultAdaptor node, out int total, out int passed, out int failed, out int skipped)
+            {
+                total = 0;
+                passed = 0;
+                failed = 0;
+                skipped = 0;
+
+                if (node == null)
+                {
+                    return;
+                }
+
+                var stack = new Stack<ITestResultAdaptor>();
+                stack.Push(node);
+
+                while (stack.Count > 0)
+                {
+                    var current = stack.Pop();
+                    if (current == null)
+                    {
+                        continue;
+                    }
+
+                    if (current.HasChildren)
+                    {
+                        foreach (var child in current.Children ?? Array.Empty<ITestResultAdaptor>())
+                        {
+                            stack.Push(child);
+                        }
+                        continue;
+                    }
+
+                    total++;
+                    switch (current.ResultState?.Status)
+                    {
+                        case TestStatus.Passed:
+                            passed++;
+                            break;
+                        case TestStatus.Failed:
+                            failed++;
+                            break;
+                        case TestStatus.Inconclusive:
+                        case TestStatus.Skipped:
+                        case TestStatus.Ignored:
+                            skipped++;
+                            break;
+                    }
+                }
+            }
         }
     }
 }

--- a/UnityMcpBridge/Editor/AIBuild.cs
+++ b/UnityMcpBridge/Editor/AIBuild.cs
@@ -212,7 +212,7 @@ namespace MCPForUnity.Editor
                             "test-suite",
                             new System.Xml.Linq.XAttribute("type", child.Test?.HasChildren == true ? "Suite" : "Test"),
                             new System.Xml.Linq.XAttribute("name", child.Name ?? "Unnamed"),
-                            new System.Xml.Linq.XAttribute("result", child.ResultState?.Status.ToString() ?? "Unknown"),
+                            new System.Xml.Linq.XAttribute("result", GetStatusString(child)),
                             BuildTestCaseElements(child)
                         );
                     }
@@ -222,9 +222,9 @@ namespace MCPForUnity.Editor
                             "test-case",
                             new System.Xml.Linq.XAttribute("name", child.Name ?? "Unnamed"),
                             new System.Xml.Linq.XAttribute("fullname", child.FullName ?? child.Name ?? "Unnamed"),
-                            new System.Xml.Linq.XAttribute("result", child.ResultState?.Status.ToString() ?? "Unknown"),
+                            new System.Xml.Linq.XAttribute("result", GetStatusString(child)),
                             new System.Xml.Linq.XAttribute("duration", child.Duration.ToString("F3")),
-                            child.ResultState?.Status == TestStatus.Failed && !string.IsNullOrEmpty(child.Message)
+                            IsFailure(child) && !string.IsNullOrEmpty(child.Message)
                                 ? new System.Xml.Linq.XElement(
                                     "failure",
                                     new System.Xml.Linq.XElement("message", child.Message ?? string.Empty),
@@ -249,7 +249,7 @@ namespace MCPForUnity.Editor
                     Failed = failed;
                     Skipped = skipped;
                     DurationSeconds = result.Duration;
-                    Result = result.ResultState?.Status.ToString() ?? "Unknown";
+                    Result = GetStatusString(result);
                 }
                 else
                 {
@@ -302,21 +302,118 @@ namespace MCPForUnity.Editor
                     }
 
                     total++;
-                    switch (current.ResultState?.Status)
+                    switch (NormalizeStatus(GetStatusString(current)))
                     {
-                        case TestStatus.Passed:
+                        case NormalizedStatus.Passed:
                             passed++;
                             break;
-                        case TestStatus.Failed:
+                        case NormalizedStatus.Failed:
                             failed++;
                             break;
-                        case TestStatus.Inconclusive:
-                        case TestStatus.Skipped:
-                        case TestStatus.Ignored:
+                        case NormalizedStatus.Skipped:
                             skipped++;
                             break;
                     }
                 }
+            }
+        }
+
+        private static bool IsFailure(ITestResultAdaptor result)
+        {
+            return NormalizeStatus(GetStatusString(result)) == NormalizedStatus.Failed;
+        }
+
+        private static string GetStatusString(ITestResultAdaptor result)
+        {
+            if (result == null)
+            {
+                return "Unknown";
+            }
+
+            try
+            {
+                var resultState = GetPropertyValue(result, "ResultState");
+                if (resultState != null)
+                {
+                    var statusValue = GetPropertyValue(resultState, "Status") ?? resultState;
+                    var statusString = statusValue?.ToString();
+                    if (!string.IsNullOrEmpty(statusString))
+                    {
+                        return statusString;
+                    }
+                }
+
+                var testStatus = GetPropertyValue(result, "TestStatus");
+                var testStatusString = testStatus?.ToString();
+                if (!string.IsNullOrEmpty(testStatusString))
+                {
+                    return testStatusString;
+                }
+            }
+            catch
+            {
+                // ignored - fall through to Unknown
+            }
+
+            return "Unknown";
+        }
+
+        private static object GetPropertyValue(object instance, string propertyName)
+        {
+            if (instance == null || string.IsNullOrEmpty(propertyName))
+            {
+                return null;
+            }
+
+            var type = instance.GetType();
+            var property = type.GetProperty(propertyName);
+            if (property == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return property.GetValue(instance, null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private enum NormalizedStatus
+        {
+            Unknown,
+            Passed,
+            Failed,
+            Skipped
+        }
+
+        private static NormalizedStatus NormalizeStatus(string status)
+        {
+            if (string.IsNullOrEmpty(status))
+            {
+                return NormalizedStatus.Unknown;
+            }
+
+            switch (status.ToLowerInvariant())
+            {
+                case "passed":
+                case "success":
+                case "succeeded":
+                    return NormalizedStatus.Passed;
+                case "failed":
+                case "failure":
+                case "error":
+                    return NormalizedStatus.Failed;
+                case "skipped":
+                case "ignored":
+                case "inconclusive":
+                case "notexecuted":
+                    return NormalizedStatus.Skipped;
+                default:
+                    return NormalizedStatus.Unknown;
             }
         }
     }

--- a/UnityMcpBridge/Editor/AIBuild.cs.meta
+++ b/UnityMcpBridge/Editor/AIBuild.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 111190d265f847b2b9dc566590192223
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityMcpBridge/Editor/MCPForUnityBridge.cs
+++ b/UnityMcpBridge/Editor/MCPForUnityBridge.cs
@@ -1055,6 +1055,10 @@ namespace MCPForUnity.Editor
                     "manage_shader" => ManageShader.HandleCommand(paramsObject),
                     "read_console" => ReadConsole.HandleCommand(paramsObject),
                     "manage_menu_item" => ManageMenuItem.HandleCommand(paramsObject),
+                    "unity_project_probe" => HandleAutomationCommand("unity_project_probe", paramsObject),
+                    "unity_compile" => HandleAutomationCommand("unity_compile", paramsObject),
+                    "unity_run_tests" => HandleAutomationCommand("unity_run_tests", paramsObject),
+                    "unity_build_il2cpp" => HandleAutomationCommand("unity_build_il2cpp", paramsObject),
                     _ => throw new ArgumentException(
                         $"Unknown or unsupported command type: {command.type}"
                     ),
@@ -1100,6 +1104,32 @@ namespace MCPForUnity.Editor
             catch (Exception ex)
             {
                 return Response.Error($"manage_scene dispatch error: {ex.Message}");
+            }
+        }
+
+        private static object HandleAutomationCommand(string commandType, JObject paramsObject)
+        {
+            try
+            {
+                if (IsDebugEnabled()) Debug.Log($"[MCP] {commandType}: dispatching to main thread");
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                Func<object> invoke = commandType switch
+                {
+                    "unity_project_probe" => () => Automation.HandleUnityProjectProbe(paramsObject),
+                    "unity_compile" => () => Automation.HandleUnityCompile(paramsObject),
+                    "unity_run_tests" => () => Automation.HandleUnityRunTests(paramsObject),
+                    "unity_build_il2cpp" => () => Automation.HandleUnityBuildIl2Cpp(paramsObject),
+                    _ => () => Response.Error($"Unknown automation command: {commandType}")
+                };
+
+                var result = InvokeOnMainThreadWithTimeout(invoke, FrameIOTimeoutMs);
+                sw.Stop();
+                if (IsDebugEnabled()) Debug.Log($"[MCP] {commandType}: completed in {sw.ElapsedMilliseconds} ms");
+                return result ?? Response.Error($"{commandType} returned null (timeout or error)");
+            }
+            catch (Exception ex)
+            {
+                return Response.Error($"{commandType} dispatch error: {ex.Message}");
             }
         }
 

--- a/UnityMcpBridge/Editor/Tools/Automation.cs
+++ b/UnityMcpBridge/Editor/Tools/Automation.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+using MCPForUnity.Editor.Helpers;
+
+namespace MCPForUnity.Editor.Tools
+{
+    /// <summary>
+    /// Provides automation commands used by the MCP pipeline (project probing, compilation, tests, builds).
+    /// </summary>
+    public static class Automation
+    {
+        public static object HandleUnityProjectProbe(JObject @params)
+        {
+            try
+            {
+                string projectPath = ResolveProjectPath(@params);
+                var data = new
+                {
+                    unityVersion = Application.unityVersion,
+                    projectPath,
+                    apiCompatibilityLevel = PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup).ToString(),
+                    scriptingBackendPerPlatform = BuildScriptingBackendMap(),
+                    packages = ReadPackages(projectPath),
+                    editorApplicationPath = EditorApplication.applicationPath,
+                    editorContentsPath = EditorApplication.applicationContentsPath,
+                    roslynCompilerPath = ResolveRoslynCompilerPath(),
+                    managedAssemblySearchPaths = ResolveAssemblySearchPaths()
+                };
+
+                return Response.Success("Unity project probe completed", data);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Automation] unity_project_probe failed: {ex.Message}\n{ex.StackTrace}");
+                return Response.Error("unity_project_probe_failed", new { message = ex.Message });
+            }
+        }
+
+        public static object HandleUnityCompile(JObject @params)
+        {
+            try
+            {
+                AIBuild.VerifyCompile();
+                var data = new
+                {
+                    logPath = Application.consoleLogPath
+                };
+                return Response.Success("Unity compilation completed", data);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Automation] unity_compile failed: {ex.Message}\n{ex.StackTrace}");
+                return Response.Error("unity_compile_failed", new { message = ex.Message });
+            }
+        }
+
+        public static object HandleUnityRunTests(JObject @params)
+        {
+            try
+            {
+                string testMode = @params?["platform"]?.ToString();
+                if (string.IsNullOrWhiteSpace(testMode))
+                {
+                    testMode = "EditMode";
+                }
+
+                string resultsPath = @params?["resultsPath"]?.ToString();
+                if (string.IsNullOrWhiteSpace(resultsPath))
+                {
+                    resultsPath = Path.Combine("Logs", $"{testMode.ToLowerInvariant()}-results.xml");
+                }
+
+                string absoluteResultsPath = AIBuild.RunTests(testMode, resultsPath);
+                var data = new
+                {
+                    resultsPath = absoluteResultsPath,
+                    logPath = Application.consoleLogPath,
+                    testMode
+                };
+
+                return Response.Success("Unity tests executed", data);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Automation] unity_run_tests failed: {ex.Message}\n{ex.StackTrace}");
+                return Response.Error("unity_run_tests_failed", new { message = ex.Message });
+            }
+        }
+
+        public static object HandleUnityBuildIl2Cpp(JObject @params)
+        {
+            // Optional capability: return a structured error if no custom build pipeline is provided.
+            return Response.Error("unity_build_il2cpp_not_implemented", new
+            {
+                message = "IL2CPP build automation is not configured for this project. Provide a BuildScript entry point to enable it."
+            });
+        }
+
+        private static string ResolveProjectPath(JObject @params)
+        {
+            string projectPath = null;
+            if (@params != null)
+            {
+                projectPath = @params.Value<string>("projectPath");
+            }
+
+            if (string.IsNullOrEmpty(projectPath))
+            {
+                projectPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            }
+            else
+            {
+                projectPath = Path.GetFullPath(projectPath);
+            }
+
+            return projectPath;
+        }
+
+        private static Dictionary<string, string> BuildScriptingBackendMap()
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (BuildTargetGroup group in Enum.GetValues(typeof(BuildTargetGroup)))
+            {
+                if (group == BuildTargetGroup.Unknown)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    ScriptingImplementation backend = PlayerSettings.GetScriptingBackend(group);
+                    if (backend != ScriptingImplementation.IL2CPP && backend != ScriptingImplementation.Mono && backend != ScriptingImplementation.WinRTDotNET)
+                    {
+                        continue;
+                    }
+
+                    result[group.ToString()] = backend.ToString();
+                }
+                catch
+                {
+                    // Ignore groups that are not supported in the current installation.
+                }
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<object> ReadPackages(string projectPath)
+        {
+            try
+            {
+                string packagesLock = Path.Combine(projectPath, "Packages", "packages-lock.json");
+                if (!File.Exists(packagesLock))
+                {
+                    return Array.Empty<object>();
+                }
+
+                string json = File.ReadAllText(packagesLock);
+                var root = JObject.Parse(json);
+                var deps = root["dependencies"] as JObject;
+                if (deps == null)
+                {
+                    return Array.Empty<object>();
+                }
+
+                return deps.Properties()
+                    .Select(p => new
+                    {
+                        name = p.Name,
+                        version = p.Value?["version"]?.ToString() ?? string.Empty
+                    })
+                    .ToArray();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[Automation] Failed to read packages-lock.json: {ex.Message}");
+                return Array.Empty<object>();
+            }
+        }
+
+        private static string ResolveRoslynCompilerPath()
+        {
+            string contents = EditorApplication.applicationContentsPath;
+            string candidate = Path.Combine(contents, "Tools", "Roslyn", Application.platform == RuntimePlatform.WindowsEditor ? "csc.exe" : "csc");
+            return File.Exists(candidate) ? candidate : string.Empty;
+        }
+
+        private static string[] ResolveAssemblySearchPaths()
+        {
+            string contents = EditorApplication.applicationContentsPath;
+            var paths = new List<string>
+            {
+                Path.Combine(contents, "Managed"),
+                Path.Combine(contents, "Managed", "UnityEngine"),
+                Path.Combine(contents, "Managed", "UnityEditor"),
+                Path.Combine(contents, "Managed", "UnityEngine", "UnityEngine"),
+                Path.Combine(contents, "MonoBleedingEdge", "lib", "mono", "4.8.0-api"),
+                Path.Combine(contents, "MonoBleedingEdge", "lib", "mono", "unityjit")
+            };
+
+            return paths.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+    }
+}

--- a/UnityMcpBridge/Editor/Tools/Automation.cs
+++ b/UnityMcpBridge/Editor/Tools/Automation.cs
@@ -134,11 +134,6 @@ namespace MCPForUnity.Editor.Tools
                 try
                 {
                     ScriptingImplementation backend = PlayerSettings.GetScriptingBackend(group);
-                    if (backend != ScriptingImplementation.IL2CPP && backend != ScriptingImplementation.Mono && backend != ScriptingImplementation.WinRTDotNET)
-                    {
-                        continue;
-                    }
-
                     result[group.ToString()] = backend.ToString();
                 }
                 catch

--- a/UnityMcpBridge/Editor/Tools/Automation.cs.meta
+++ b/UnityMcpBridge/Editor/Tools/Automation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e087e220f2fe4e5494573f3bf21e74e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
+++ b/UnityMcpBridge/UnityMcpServer~/src/pyproject.toml
@@ -4,7 +4,11 @@ version = "3.4.0"
 description = "MCP for Unity Server: A Unity package for Unity Editor integration via the Model Context Protocol (MCP)."
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["httpx>=0.27.2", "mcp[cli]>=1.4.1"]
+dependencies = [
+  "httpx>=0.27.2",
+  "mcp[cli]>=1.4.1",
+  "pydantic>=2.7",
+]
 
 [build-system]
 requires = ["setuptools>=64.0.0", "wheel"]

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/__init__.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/__init__.py
@@ -9,6 +9,7 @@ from .manage_shader import register_manage_shader_tools
 from .read_console import register_read_console_tools
 from .manage_menu_item import register_manage_menu_item_tools
 from .resource_tools import register_resource_tools
+from .unity_pipeline import register_unity_pipeline_tools
 
 logger = logging.getLogger("mcp-for-unity-server")
 
@@ -26,4 +27,5 @@ def register_all_tools(mcp):
     register_read_console_tools(mcp)
     register_manage_menu_item_tools(mcp)
     register_resource_tools(mcp)
+    register_unity_pipeline_tools(mcp)
     logger.info("MCP for Unity Server tool registration complete.")

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/pipeline_runner.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/pipeline_runner.py
@@ -32,22 +32,35 @@ def _write_result(path: Path, result) -> None:
         handle.write("\n")
 
 
-def run_pipeline(project_path: Path, log_dir: Path, include_playmode: bool = True, run_il2cpp: bool = False) -> None:
+def run_pipeline(
+    project_path: Path,
+    log_dir: Path,
+    include_playmode: bool = True,
+    run_il2cpp: bool = False,
+) -> None:
     project_path = project_path.resolve()
     log_dir = log_dir.resolve()
 
     steps: Dict[str, Callable[[], CommandResult]] = {
         "unity_project_probe": lambda: _unity_project_probe_impl(project_path),
-        "roslyn_check": lambda: _roslyn_check_impl(project_path, _DEFAULT_SOURCE_GLOB, "9.0"),
+        "roslyn_check": lambda: _roslyn_check_impl(
+            project_path, _DEFAULT_SOURCE_GLOB, "9.0"
+        ),
         "unity_compile": lambda: _unity_compile_impl(project_path, None),
-        "unity_run_tests_editmode": lambda: _unity_run_tests_impl(project_path, "EditMode", None),
+        "unity_run_tests_editmode": lambda: _unity_run_tests_impl(
+            project_path, "EditMode", None
+        ),
     }
 
     if include_playmode:
-        steps["unity_run_tests_playmode"] = lambda: _unity_run_tests_impl(project_path, "PlayMode", None)
+        steps["unity_run_tests_playmode"] = lambda: _unity_run_tests_impl(
+            project_path, "PlayMode", None
+        )
 
     if run_il2cpp:
-        steps["unity_build_il2cpp"] = lambda: _unity_build_il2cpp_impl(project_path, "Standalone", None)
+        steps["unity_build_il2cpp"] = lambda: _unity_build_il2cpp_impl(
+            project_path, "Standalone", None
+        )
 
     failed_steps: List[str] = []
     worst_exit = 0
@@ -62,19 +75,37 @@ def run_pipeline(project_path: Path, log_dir: Path, include_playmode: bool = Tru
 
     if failed_steps:
         message = ", ".join(failed_steps)
-        print(f"[pipeline_runner] Failure in steps: {message}", file=sys.stderr)
+        sys.stderr.write(f"[pipeline_runner] Failure in steps: {message}\n")
         raise SystemExit(worst_exit or 1)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Execute the Unity MCP pipeline locally.")
-    parser.add_argument("--project", dest="project", required=True, help="Path to the Unity project root")
-    parser.add_argument("--log-dir", dest="log_dir", default="logs", help="Directory for JSON outputs")
-    parser.add_argument("--no-playmode", action="store_true", help="Skip play mode tests")
-    parser.add_argument("--il2cpp", action="store_true", help="Attempt IL2CPP build step")
+    parser = argparse.ArgumentParser(
+        description="Execute the Unity MCP pipeline locally."
+    )
+    parser.add_argument(
+        "--project",
+        dest="project",
+        required=True,
+        help="Path to the Unity project root",
+    )
+    parser.add_argument(
+        "--log-dir", dest="log_dir", default="logs", help="Directory for JSON outputs"
+    )
+    parser.add_argument(
+        "--no-playmode", action="store_true", help="Skip play mode tests"
+    )
+    parser.add_argument(
+        "--il2cpp", action="store_true", help="Attempt IL2CPP build step"
+    )
     args = parser.parse_args()
 
-    run_pipeline(Path(args.project), Path(args.log_dir), include_playmode=not args.no_playmode, run_il2cpp=args.il2cpp)
+    run_pipeline(
+        Path(args.project),
+        Path(args.log_dir),
+        include_playmode=not args.no_playmode,
+        run_il2cpp=args.il2cpp,
+    )
 
 
 if __name__ == "__main__":

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/pipeline_runner.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/pipeline_runner.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List
+
+from .unity_pipeline import (
+    _unity_project_probe_impl,
+    _roslyn_check_impl,
+    _unity_compile_impl,
+    _unity_run_tests_impl,
+    _unity_build_il2cpp_impl,
+    _DEFAULT_SOURCE_GLOB,
+    CommandResult,
+)
+
+
+def _write_result(path: Path, result) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        payload = {
+            "ok": bool(result.ok),
+            "exitCode": int(result.exit_code),
+        }
+        if result.data is not None:
+            payload["data"] = result.data
+        if result.errors:
+            payload["errors"] = result.errors
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def run_pipeline(project_path: Path, log_dir: Path, include_playmode: bool = True, run_il2cpp: bool = False) -> None:
+    project_path = project_path.resolve()
+    log_dir = log_dir.resolve()
+
+    steps: Dict[str, Callable[[], CommandResult]] = {
+        "unity_project_probe": lambda: _unity_project_probe_impl(project_path),
+        "roslyn_check": lambda: _roslyn_check_impl(project_path, _DEFAULT_SOURCE_GLOB, "9.0"),
+        "unity_compile": lambda: _unity_compile_impl(project_path, None),
+        "unity_run_tests_editmode": lambda: _unity_run_tests_impl(project_path, "EditMode", None),
+    }
+
+    if include_playmode:
+        steps["unity_run_tests_playmode"] = lambda: _unity_run_tests_impl(project_path, "PlayMode", None)
+
+    if run_il2cpp:
+        steps["unity_build_il2cpp"] = lambda: _unity_build_il2cpp_impl(project_path, "Standalone", None)
+
+    failed_steps: List[str] = []
+    worst_exit = 0
+
+    for name, action in steps.items():
+        result = action()
+        _write_result(log_dir / f"{name}.json", result)
+        if not result.ok:
+            exit_code = int(result.exit_code) if result.exit_code is not None else 1
+            worst_exit = max(worst_exit, exit_code)
+            failed_steps.append(f"{name} (exit {exit_code})")
+
+    if failed_steps:
+        message = ", ".join(failed_steps)
+        print(f"[pipeline_runner] Failure in steps: {message}", file=sys.stderr)
+        raise SystemExit(worst_exit or 1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Execute the Unity MCP pipeline locally.")
+    parser.add_argument("--project", dest="project", required=True, help="Path to the Unity project root")
+    parser.add_argument("--log-dir", dest="log_dir", default="logs", help="Directory for JSON outputs")
+    parser.add_argument("--no-playmode", action="store_true", help="Skip play mode tests")
+    parser.add_argument("--il2cpp", action="store_true", help="Attempt IL2CPP build step")
+    args = parser.parse_args()
+
+    run_pipeline(Path(args.project), Path(args.log_dir), include_playmode=not args.no_playmode, run_il2cpp=args.il2cpp)
+
+
+if __name__ == "__main__":
+    main()

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/unity_pipeline.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/unity_pipeline.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+# from __future__ import annotations  # Removed to fix MCP Context type annotation issue
 
 import json
 import logging
@@ -27,26 +27,36 @@ class UnityProjectProbeArgs(BaseModel):
 
 class RoslynCheckArgs(BaseModel):
     projectPath: str = Field(..., description="Absolute path to the Unity project root")
-    glob: Optional[str] = Field(default=None, description="Glob pattern for source discovery")
+    glob: Optional[str] = Field(
+        default=None, description="Glob pattern for source discovery"
+    )
     langVersion: Optional[str] = Field(default="9.0", description="C# language version")
 
 
 class UnityCompileArgs(BaseModel):
     projectPath: str = Field(..., description="Absolute path to the Unity project root")
-    logPath: Optional[str] = Field(default=None, description="Optional override for log path")
+    logPath: Optional[str] = Field(
+        default=None, description="Optional override for log path"
+    )
 
 
 class UnityRunTestsArgs(BaseModel):
     projectPath: str = Field(..., description="Absolute path to the Unity project root")
     platform: str = Field(..., description="EditMode or PlayMode")
-    resultsPath: Optional[str] = Field(default=None, description="Optional override for NUnit XML path")
-    nographics: Optional[bool] = Field(default=None, description="Reserved for batchmode compatibility")
+    resultsPath: Optional[str] = Field(
+        default=None, description="Optional override for NUnit XML path"
+    )
+    nographics: Optional[bool] = Field(
+        default=None, description="Reserved for batchmode compatibility"
+    )
 
 
 class UnityBuildIL2CPPArgs(BaseModel):
     projectPath: str = Field(..., description="Absolute path to the Unity project root")
     target: str = Field(..., description="Unity build target")
-    outputDir: Optional[str] = Field(default=None, description="Optional build output directory")
+    outputDir: Optional[str] = Field(
+        default=None, description="Optional build output directory"
+    )
 
 
 @dataclass
@@ -58,11 +68,15 @@ class CommandResult:
 
 
 _DEFAULT_SOURCE_GLOB = "Assets/AI.Generated/**/*.cs"
-_CSC_ERROR_RE = re.compile(r"^(?P<file>[^:(]+)\((?P<line>\d+)(?:,(?P<column>\d+))?\): (?P<kind>error|warning) (?P<code>[A-Z]+\d+): (?P<message>.*)$")
+_CSC_ERROR_RE = re.compile(
+    r"^(?P<file>[^:(]+)\((?P<line>\d+)(?:,(?P<column>\d+))?\): (?P<kind>error|warning) (?P<code>[A-Z]+\d+): (?P<message>.*)$"
+)
 
 
 def _is_offline_mode() -> bool:
-    value = os.environ.get("UNITY_MCP_SKIP_STARTUP_CONNECT") or os.environ.get("UNITY_MCP_OFFLINE")
+    value = os.environ.get("UNITY_MCP_SKIP_STARTUP_CONNECT") or os.environ.get(
+        "UNITY_MCP_OFFLINE"
+    )
     if not value:
         return False
     return value.lower() in {"1", "true", "yes", "on"}
@@ -86,8 +100,14 @@ def register_unity_pipeline_tools(mcp: FastMCP) -> None:
         glob: Optional[str] = None,
         langVersion: Optional[str] = None,
     ) -> Dict[str, Any]:  # type: ignore[override]
-        args = _validated(RoslynCheckArgs, projectPath=projectPath, glob=glob, langVersion=langVersion)
-        result = _roslyn_check_impl(Path(args.projectPath), args.glob or _DEFAULT_SOURCE_GLOB, args.langVersion or "9.0")
+        args = _validated(
+            RoslynCheckArgs, projectPath=projectPath, glob=glob, langVersion=langVersion
+        )
+        result = _roslyn_check_impl(
+            Path(args.projectPath),
+            args.glob or _DEFAULT_SOURCE_GLOB,
+            args.langVersion or "9.0",
+        )
         return _as_dict(result)
 
     @mcp.tool()
@@ -113,7 +133,9 @@ def register_unity_pipeline_tools(mcp: FastMCP) -> None:
             resultsPath=resultsPath,
             nographics=nographics,
         )
-        result = _unity_run_tests_impl(Path(args.projectPath), args.platform, args.resultsPath)
+        result = _unity_run_tests_impl(
+            Path(args.projectPath), args.platform, args.resultsPath
+        )
         return _as_dict(result)
 
     @mcp.tool()
@@ -124,8 +146,15 @@ def register_unity_pipeline_tools(mcp: FastMCP) -> None:
         target: str,
         outputDir: Optional[str] = None,
     ) -> Dict[str, Any]:  # type: ignore[override]
-        args = _validated(UnityBuildIL2CPPArgs, projectPath=projectPath, target=target, outputDir=outputDir)
-        result = _unity_build_il2cpp_impl(Path(args.projectPath), args.target, args.outputDir)
+        args = _validated(
+            UnityBuildIL2CPPArgs,
+            projectPath=projectPath,
+            target=target,
+            outputDir=outputDir,
+        )
+        result = _unity_build_il2cpp_impl(
+            Path(args.projectPath), args.target, args.outputDir
+        )
         return _as_dict(result)
 
 
@@ -151,7 +180,9 @@ def _unity_project_probe_impl(project_path: Path) -> CommandResult:
         data = _offline_project_probe(project_path)
         return CommandResult(ok=True, exit_code=0, data=data)
     try:
-        response = send_command_with_retry("unity_project_probe", {"projectPath": str(project_path)})
+        response = send_command_with_retry(
+            "unity_project_probe", {"projectPath": str(project_path)}
+        )
     except Exception as exc:
         logger.error("unity_project_probe failed: %s", exc)
         return CommandResult(
@@ -159,10 +190,14 @@ def _unity_project_probe_impl(project_path: Path) -> CommandResult:
             exit_code=1,
             errors=[{"message": str(exc), "code": "unity_project_probe_failed"}],
         )
-    return _normalize_bridge_response(response, default_error_code="unity_project_probe_failed")
+    return _normalize_bridge_response(
+        response, default_error_code="unity_project_probe_failed"
+    )
 
 
-def _roslyn_check_impl(project_path: Path, glob_pattern: str, lang_version: str) -> CommandResult:
+def _roslyn_check_impl(
+    project_path: Path, glob_pattern: str, lang_version: str
+) -> CommandResult:
     project_path = _ensure_project_path(project_path)
     files = sorted(str(p) for p in project_path.glob(glob_pattern) if p.is_file())
     if not files:
@@ -170,7 +205,9 @@ def _roslyn_check_impl(project_path: Path, glob_pattern: str, lang_version: str)
 
     probe = _unity_project_probe_impl(project_path)
     if not probe.ok:
-        return CommandResult(ok=False, exit_code=probe.exit_code or 1, errors=probe.errors)
+        return CommandResult(
+            ok=False, exit_code=probe.exit_code or 1, errors=probe.errors
+        )
 
     data = probe.data or {}
     csc_path = data.get("roslynCompilerPath") or os.environ.get("UNITY_CSC_PATH")
@@ -178,7 +215,12 @@ def _roslyn_check_impl(project_path: Path, glob_pattern: str, lang_version: str)
         return CommandResult(
             ok=False,
             exit_code=2,
-            errors=[{"message": "Unable to locate Roslyn compiler (csc).", "code": "CSC_NOT_FOUND"}],
+            errors=[
+                {
+                    "message": "Unable to locate Roslyn compiler (csc).",
+                    "code": "CSC_NOT_FOUND",
+                }
+            ],
         )
 
     csc_executable = Path(csc_path)
@@ -186,7 +228,12 @@ def _roslyn_check_impl(project_path: Path, glob_pattern: str, lang_version: str)
         return CommandResult(
             ok=False,
             exit_code=2,
-            errors=[{"message": f"Roslyn compiler not found at {csc_executable}", "code": "CSC_NOT_FOUND"}],
+            errors=[
+                {
+                    "message": f"Roslyn compiler not found at {csc_executable}",
+                    "code": "CSC_NOT_FOUND",
+                }
+            ],
         )
 
     references = _gather_reference_assemblies(project_path, data)
@@ -219,20 +266,34 @@ def _roslyn_check_impl(project_path: Path, glob_pattern: str, lang_version: str)
             return CommandResult(
                 ok=False,
                 exit_code=2,
-                errors=[{"message": f"Roslyn compiler missing: {csc_executable}", "code": "CSC_NOT_FOUND"}],
+                errors=[
+                    {
+                        "message": f"Roslyn compiler missing: {csc_executable}",
+                        "code": "CSC_NOT_FOUND",
+                    }
+                ],
             )
         except subprocess.TimeoutExpired:
             return CommandResult(
                 ok=False,
                 exit_code=3,
-                errors=[{"message": "Roslyn compilation timed out", "code": "CSC_TIMEOUT"}],
+                errors=[
+                    {"message": "Roslyn compilation timed out", "code": "CSC_TIMEOUT"}
+                ],
             )
 
-        diagnostics = _parse_csc_output(result.stdout, result.stderr, base_path=project_path)
+        diagnostics = _parse_csc_output(
+            result.stdout, result.stderr, base_path=project_path
+        )
         ok = result.returncode == 0
         exit_code = 0 if ok else result.returncode
         payload = {"checked": len(files), "errors": diagnostics}
-        return CommandResult(ok=ok, exit_code=exit_code, data=payload, errors=diagnostics if not ok else None)
+        return CommandResult(
+            ok=ok,
+            exit_code=exit_code,
+            data=payload,
+            errors=diagnostics if not ok else None,
+        )
 
 
 def _unity_compile_impl(project_path: Path, log_path: Optional[str]) -> CommandResult:
@@ -241,13 +302,22 @@ def _unity_compile_impl(project_path: Path, log_path: Optional[str]) -> CommandR
         return CommandResult(
             ok=False,
             exit_code=1,
-            errors=[{"message": "Unity connection is not available in offline mode", "code": "unity_compile_unavailable"}],
+            errors=[
+                {
+                    "message": "Unity connection is not available in offline mode",
+                    "code": "unity_compile_unavailable",
+                }
+            ],
         )
     _clear_console()
     try:
         response = send_command_with_retry(
             "unity_compile",
-            {"projectPath": str(project_path), "logPath": log_path} if log_path else {"projectPath": str(project_path)},
+            (
+                {"projectPath": str(project_path), "logPath": log_path}
+                if log_path
+                else {"projectPath": str(project_path)}
+            ),
         )
     except Exception as exc:
         logger.error("unity_compile failed: %s", exc)
@@ -256,7 +326,9 @@ def _unity_compile_impl(project_path: Path, log_path: Optional[str]) -> CommandR
             exit_code=1,
             errors=[{"message": str(exc), "code": "unity_compile_failed"}],
         )
-    bridge = _normalize_bridge_response(response, default_error_code="unity_compile_failed")
+    bridge = _normalize_bridge_response(
+        response, default_error_code="unity_compile_failed"
+    )
     if not bridge.ok:
         return bridge
 
@@ -264,7 +336,9 @@ def _unity_compile_impl(project_path: Path, log_path: Optional[str]) -> CommandR
     errors = [entry for entry in logs if entry.get("type") == "error"]
     warnings = [entry for entry in logs if entry.get("type") == "warning"]
     parsed_errors = [_parse_console_diagnostic(entry, project_path) for entry in errors]
-    parsed_warnings = [_parse_console_diagnostic(entry, project_path) for entry in warnings]
+    parsed_warnings = [
+        _parse_console_diagnostic(entry, project_path) for entry in warnings
+    ]
     parsed_errors = [e for e in parsed_errors if e]
     parsed_warnings = [w for w in parsed_warnings if w]
 
@@ -274,16 +348,28 @@ def _unity_compile_impl(project_path: Path, log_path: Optional[str]) -> CommandR
         "warnings": parsed_warnings,
         "rawLogPath": bridge.data.get("logPath") if bridge.data else None,
     }
-    return CommandResult(ok=ok, exit_code=0 if ok else 1, data=payload, errors=parsed_errors if not ok else None)
+    return CommandResult(
+        ok=ok,
+        exit_code=0 if ok else 1,
+        data=payload,
+        errors=parsed_errors if not ok else None,
+    )
 
 
-def _unity_run_tests_impl(project_path: Path, platform: str, results_path: Optional[str]) -> CommandResult:
+def _unity_run_tests_impl(
+    project_path: Path, platform: str, results_path: Optional[str]
+) -> CommandResult:
     project_path = _ensure_project_path(project_path)
     if _is_offline_mode():
         return CommandResult(
             ok=False,
             exit_code=1,
-            errors=[{"message": "Unity connection is not available in offline mode", "code": "unity_tests_unavailable"}],
+            errors=[
+                {
+                    "message": "Unity connection is not available in offline mode",
+                    "code": "unity_tests_unavailable",
+                }
+            ],
         )
     _clear_console()
     try:
@@ -302,7 +388,9 @@ def _unity_run_tests_impl(project_path: Path, platform: str, results_path: Optio
             exit_code=1,
             errors=[{"message": str(exc), "code": "unity_run_tests_failed"}],
         )
-    bridge = _normalize_bridge_response(response, default_error_code="unity_run_tests_failed")
+    bridge = _normalize_bridge_response(
+        response, default_error_code="unity_run_tests_failed"
+    )
     if not bridge.ok:
         return bridge
 
@@ -312,7 +400,12 @@ def _unity_run_tests_impl(project_path: Path, platform: str, results_path: Optio
         return CommandResult(
             ok=False,
             exit_code=1,
-            errors=[{"message": "Unity did not return a resultsPath", "code": "TEST_RESULTS_MISSING"}],
+            errors=[
+                {
+                    "message": "Unity did not return a resultsPath",
+                    "code": "TEST_RESULTS_MISSING",
+                }
+            ],
         )
 
     summary = _parse_nunit_results(Path(results_file))
@@ -320,7 +413,12 @@ def _unity_run_tests_impl(project_path: Path, platform: str, results_path: Optio
         return CommandResult(
             ok=False,
             exit_code=1,
-            errors=[{"message": f"Unable to parse NUnit results at {results_file}", "code": "TEST_RESULTS_PARSE"}],
+            errors=[
+                {
+                    "message": f"Unable to parse NUnit results at {results_file}",
+                    "code": "TEST_RESULTS_PARSE",
+                }
+            ],
         )
 
     ok = summary["failed"] == 0
@@ -332,29 +430,44 @@ def _unity_run_tests_impl(project_path: Path, platform: str, results_path: Optio
         "resultsPath": results_file,
         "logPath": data.get("logPath"),
     }
-    errors = [
-        {
-            "message": failure["message"],
-            "file": failure.get("file"),
-            "line": failure.get("line"),
-        }
-        for failure in summary["failures"]
-    ] if not ok else None
+    errors = (
+        [
+            {
+                "message": failure["message"],
+                "file": failure.get("file"),
+                "line": failure.get("line"),
+            }
+            for failure in summary["failures"]
+        ]
+        if not ok
+        else None
+    )
     return CommandResult(ok=ok, exit_code=0 if ok else 1, data=payload, errors=errors)
 
 
-def _unity_build_il2cpp_impl(project_path: Path, target: str, output_dir: Optional[str]) -> CommandResult:
+def _unity_build_il2cpp_impl(
+    project_path: Path, target: str, output_dir: Optional[str]
+) -> CommandResult:
     project_path = _ensure_project_path(project_path)
     if _is_offline_mode():
         return CommandResult(
             ok=False,
             exit_code=1,
-            errors=[{"message": "Unity connection is not available in offline mode", "code": "unity_build_il2cpp_unavailable"}],
+            errors=[
+                {
+                    "message": "Unity connection is not available in offline mode",
+                    "code": "unity_build_il2cpp_unavailable",
+                }
+            ],
         )
     try:
         response = send_command_with_retry(
             "unity_build_il2cpp",
-            {"projectPath": str(project_path), "target": target, "outputDir": output_dir},
+            {
+                "projectPath": str(project_path),
+                "target": target,
+                "outputDir": output_dir,
+            },
         )
     except Exception as exc:
         logger.error("unity_build_il2cpp failed: %s", exc)
@@ -363,7 +476,9 @@ def _unity_build_il2cpp_impl(project_path: Path, target: str, output_dir: Option
             exit_code=1,
             errors=[{"message": str(exc), "code": "unity_build_il2cpp_failed"}],
         )
-    bridge = _normalize_bridge_response(response, default_error_code="unity_build_il2cpp_failed")
+    bridge = _normalize_bridge_response(
+        response, default_error_code="unity_build_il2cpp_failed"
+    )
     if bridge.ok:
         return bridge
     return CommandResult(
@@ -379,7 +494,9 @@ def _ensure_project_path(project_path: Path) -> Path:
     return project_path.resolve()
 
 
-def _normalize_bridge_response(response: Dict[str, Any], default_error_code: str) -> CommandResult:
+def _normalize_bridge_response(
+    response: Dict[str, Any], default_error_code: str
+) -> CommandResult:
     if isinstance(response, dict) and response.get("success"):
         data = response.get("data") or {}
         return CommandResult(ok=True, exit_code=0, data=data)
@@ -387,12 +504,18 @@ def _normalize_bridge_response(response: Dict[str, Any], default_error_code: str
     error_message = "Unknown Unity error"
     code = default_error_code
     if isinstance(response, dict):
-        error_message = response.get("message") or response.get("error") or error_message
+        error_message = (
+            response.get("message") or response.get("error") or error_message
+        )
         code = response.get("code") or code
-    return CommandResult(ok=False, exit_code=1, errors=[{"message": error_message, "code": code}])
+    return CommandResult(
+        ok=False, exit_code=1, errors=[{"message": error_message, "code": code}]
+    )
 
 
-def _gather_reference_assemblies(project_path: Path, probe_data: Dict[str, Any]) -> List[str]:
+def _gather_reference_assemblies(
+    project_path: Path, probe_data: Dict[str, Any]
+) -> List[str]:
     paths = []
     search_paths = probe_data.get("managedAssemblySearchPaths") or []
     for entry in search_paths:
@@ -430,9 +553,11 @@ def _gather_reference_assemblies(project_path: Path, probe_data: Dict[str, Any])
     return sorted(set(references))
 
 
-def _parse_csc_output(stdout: str, stderr: str, base_path: Path) -> List[Dict[str, Any]]:
+def _parse_csc_output(
+    stdout: str, stderr: str, base_path: Path
+) -> List[Dict[str, Any]]:
     diagnostics: List[Dict[str, Any]] = []
-    for line in (stdout.splitlines() + stderr.splitlines()):
+    for line in stdout.splitlines() + stderr.splitlines():
         match = _CSC_ERROR_RE.match(line.strip())
         if not match:
             continue
@@ -484,7 +609,9 @@ def _collect_console_entries(types: List[str]) -> List[Dict[str, Any]]:
     return response.get("data", {}).get("lines", []) or []
 
 
-def _parse_console_diagnostic(entry: Dict[str, Any], project_path: Path) -> Optional[Dict[str, Any]]:
+def _parse_console_diagnostic(
+    entry: Dict[str, Any], project_path: Path
+) -> Optional[Dict[str, Any]]:
     message = entry.get("message") or entry.get("content")
     if not message:
         return None
@@ -555,8 +682,14 @@ def _parse_nunit_results(path: Path) -> Optional[Dict[str, Any]]:
         if failure_node is not None:
             message_node = failure_node.find("message")
             stack_node = failure_node.find("stack-trace")
-            message = message_node.text if message_node is not None and message_node.text else ""
-            stack = stack_node.text if stack_node is not None and stack_node.text else ""
+            message = (
+                message_node.text
+                if message_node is not None and message_node.text
+                else ""
+            )
+            stack = (
+                stack_node.text if stack_node is not None and stack_node.text else ""
+            )
         failures.append(
             {
                 "testName": case.get("fullname") or case.get("name"),
@@ -577,7 +710,9 @@ def _offline_project_probe(project_path: Path) -> Dict[str, Any]:
     version = "unknown"
     version_file = project_path / "ProjectSettings" / "ProjectVersion.txt"
     if version_file.exists():
-        for line in version_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+        for line in version_file.read_text(
+            encoding="utf-8", errors="ignore"
+        ).splitlines():
             if "m_EditorVersion" in line:
                 version = line.split(":", 1)[-1].strip()
                 break
@@ -603,10 +738,10 @@ def _offline_project_probe(project_path: Path) -> Dict[str, Any]:
         for line in text.splitlines():
             line = line.strip()
             if line.startswith("apiCompatibilityLevel:") and "Standalone" in line:
-                value = line.split("Standalone", 1)[-1].strip().strip('{}[]:, ')
+                value = line.split("Standalone", 1)[-1].strip().strip("{}[]:, ")
                 api_level = api_map.get(value, value or api_level)
             if line.startswith("scriptingBackend:") and "Standalone" in line:
-                value = line.split("Standalone", 1)[-1].strip().strip('{}[]:, ')
+                value = line.split("Standalone", 1)[-1].strip().strip("{}[]:, ")
                 scripting_backends["Standalone"] = backend_map.get(value, value)
 
     packages = []

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/unity_pipeline.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/unity_pipeline.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree
+
+from mcp.server.fastmcp import FastMCP, Context
+from pydantic import BaseModel, Field, ValidationError
+
+from config import config
+from telemetry_decorator import telemetry_tool
+from unity_connection import send_command_with_retry
+
+logger = logging.getLogger("mcp-for-unity-server")
+
+
+class UnityProjectProbeArgs(BaseModel):
+    projectPath: str = Field(..., description="Absolute path to the Unity project root")
+
+
+class RoslynCheckArgs(BaseModel):
+    projectPath: str = Field(..., description="Absolute path to the Unity project root")
+    glob: Optional[str] = Field(default=None, description="Glob pattern for source discovery")
+    langVersion: Optional[str] = Field(default="9.0", description="C# language version")
+
+
+class UnityCompileArgs(BaseModel):
+    projectPath: str = Field(..., description="Absolute path to the Unity project root")
+    logPath: Optional[str] = Field(default=None, description="Optional override for log path")
+
+
+class UnityRunTestsArgs(BaseModel):
+    projectPath: str = Field(..., description="Absolute path to the Unity project root")
+    platform: str = Field(..., description="EditMode or PlayMode")
+    resultsPath: Optional[str] = Field(default=None, description="Optional override for NUnit XML path")
+    nographics: Optional[bool] = Field(default=None, description="Reserved for batchmode compatibility")
+
+
+class UnityBuildIL2CPPArgs(BaseModel):
+    projectPath: str = Field(..., description="Absolute path to the Unity project root")
+    target: str = Field(..., description="Unity build target")
+    outputDir: Optional[str] = Field(default=None, description="Optional build output directory")
+
+
+@dataclass
+class CommandResult:
+    ok: bool
+    exit_code: int
+    data: Optional[Dict[str, Any]] = None
+    errors: Optional[List[Dict[str, Any]]] = None
+
+
+_DEFAULT_SOURCE_GLOB = "Assets/AI.Generated/**/*.cs"
+_CSC_ERROR_RE = re.compile(r"^(?P<file>[^:(]+)\((?P<line>\d+)(?:,(?P<column>\d+))?\): (?P<kind>error|warning) (?P<code>[A-Z]+\d+): (?P<message>.*)$")
+
+
+def _is_offline_mode() -> bool:
+    value = os.environ.get("UNITY_MCP_SKIP_STARTUP_CONNECT") or os.environ.get("UNITY_MCP_OFFLINE")
+    if not value:
+        return False
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def register_unity_pipeline_tools(mcp: FastMCP) -> None:
+    """Register build/test automation tools with the MCP server."""
+
+    @mcp.tool()
+    @telemetry_tool("unity_project_probe")
+    def unity_project_probe(ctx: Context, projectPath: str) -> Dict[str, Any]:  # type: ignore[override]
+        args = _validated(UnityProjectProbeArgs, projectPath=projectPath)
+        result = _unity_project_probe_impl(Path(args.projectPath))
+        return _as_dict(result)
+
+    @mcp.tool()
+    @telemetry_tool("roslyn_check")
+    def roslyn_check(
+        ctx: Context,
+        projectPath: str,
+        glob: Optional[str] = None,
+        langVersion: Optional[str] = None,
+    ) -> Dict[str, Any]:  # type: ignore[override]
+        args = _validated(RoslynCheckArgs, projectPath=projectPath, glob=glob, langVersion=langVersion)
+        result = _roslyn_check_impl(Path(args.projectPath), args.glob or _DEFAULT_SOURCE_GLOB, args.langVersion or "9.0")
+        return _as_dict(result)
+
+    @mcp.tool()
+    @telemetry_tool("unity_compile")
+    def unity_compile(ctx: Context, projectPath: str, logPath: Optional[str] = None) -> Dict[str, Any]:  # type: ignore[override]
+        args = _validated(UnityCompileArgs, projectPath=projectPath, logPath=logPath)
+        result = _unity_compile_impl(Path(args.projectPath), args.logPath)
+        return _as_dict(result)
+
+    @mcp.tool()
+    @telemetry_tool("unity_run_tests")
+    def unity_run_tests(
+        ctx: Context,
+        projectPath: str,
+        platform: str,
+        resultsPath: Optional[str] = None,
+        nographics: Optional[bool] = None,
+    ) -> Dict[str, Any]:  # type: ignore[override]
+        args = _validated(
+            UnityRunTestsArgs,
+            projectPath=projectPath,
+            platform=platform,
+            resultsPath=resultsPath,
+            nographics=nographics,
+        )
+        result = _unity_run_tests_impl(Path(args.projectPath), args.platform, args.resultsPath)
+        return _as_dict(result)
+
+    @mcp.tool()
+    @telemetry_tool("unity_build_il2cpp")
+    def unity_build_il2cpp(
+        ctx: Context,
+        projectPath: str,
+        target: str,
+        outputDir: Optional[str] = None,
+    ) -> Dict[str, Any]:  # type: ignore[override]
+        args = _validated(UnityBuildIL2CPPArgs, projectPath=projectPath, target=target, outputDir=outputDir)
+        result = _unity_build_il2cpp_impl(Path(args.projectPath), args.target, args.outputDir)
+        return _as_dict(result)
+
+
+def _validated(model: type[BaseModel], **kwargs) -> BaseModel:
+    try:
+        return model(**kwargs)
+    except ValidationError as exc:
+        raise ValueError(exc.errors()) from exc
+
+
+def _as_dict(result: CommandResult) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"ok": bool(result.ok), "exitCode": int(result.exit_code)}
+    if result.data is not None:
+        payload["data"] = result.data
+    if result.errors:
+        payload["errors"] = result.errors
+    return payload
+
+
+def _unity_project_probe_impl(project_path: Path) -> CommandResult:
+    project_path = _ensure_project_path(project_path)
+    if _is_offline_mode():
+        data = _offline_project_probe(project_path)
+        return CommandResult(ok=True, exit_code=0, data=data)
+    try:
+        response = send_command_with_retry("unity_project_probe", {"projectPath": str(project_path)})
+    except Exception as exc:
+        logger.error("unity_project_probe failed: %s", exc)
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": str(exc), "code": "unity_project_probe_failed"}],
+        )
+    return _normalize_bridge_response(response, default_error_code="unity_project_probe_failed")
+
+
+def _roslyn_check_impl(project_path: Path, glob_pattern: str, lang_version: str) -> CommandResult:
+    project_path = _ensure_project_path(project_path)
+    files = sorted(str(p) for p in project_path.glob(glob_pattern) if p.is_file())
+    if not files:
+        return CommandResult(ok=True, exit_code=0, data={"checked": 0, "errors": []})
+
+    probe = _unity_project_probe_impl(project_path)
+    if not probe.ok:
+        return CommandResult(ok=False, exit_code=probe.exit_code or 1, errors=probe.errors)
+
+    data = probe.data or {}
+    csc_path = data.get("roslynCompilerPath") or os.environ.get("UNITY_CSC_PATH")
+    if not csc_path:
+        return CommandResult(
+            ok=False,
+            exit_code=2,
+            errors=[{"message": "Unable to locate Roslyn compiler (csc).", "code": "CSC_NOT_FOUND"}],
+        )
+
+    csc_executable = Path(csc_path)
+    if not csc_executable.exists():
+        return CommandResult(
+            ok=False,
+            exit_code=2,
+            errors=[{"message": f"Roslyn compiler not found at {csc_executable}", "code": "CSC_NOT_FOUND"}],
+        )
+
+    references = _gather_reference_assemblies(project_path, data)
+    with tempfile.TemporaryDirectory(prefix="unity-roslyn-") as tmp:
+        output_path = Path(tmp) / "DryCompile.dll"
+        cmd = [
+            str(csc_executable),
+            "/nologo",
+            "/t:library",
+            f"/langversion:{lang_version}",
+            "/nowarn:CS1591",
+            "/unsafe-",
+            "/deterministic",
+            f"/out:{output_path}",
+        ]
+        cmd.extend(f"/reference:{ref}" for ref in references)
+        cmd.extend(files)
+
+        logger.debug("Running Roslyn check: %s", " ".join(cmd))
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(project_path),
+                capture_output=True,
+                text=True,
+                timeout=getattr(config, "roslyn_timeout_sec", 120),
+                check=False,
+            )
+        except FileNotFoundError:
+            return CommandResult(
+                ok=False,
+                exit_code=2,
+                errors=[{"message": f"Roslyn compiler missing: {csc_executable}", "code": "CSC_NOT_FOUND"}],
+            )
+        except subprocess.TimeoutExpired:
+            return CommandResult(
+                ok=False,
+                exit_code=3,
+                errors=[{"message": "Roslyn compilation timed out", "code": "CSC_TIMEOUT"}],
+            )
+
+        diagnostics = _parse_csc_output(result.stdout, result.stderr, base_path=project_path)
+        ok = result.returncode == 0
+        exit_code = 0 if ok else result.returncode
+        payload = {"checked": len(files), "errors": diagnostics}
+        return CommandResult(ok=ok, exit_code=exit_code, data=payload, errors=diagnostics if not ok else None)
+
+
+def _unity_compile_impl(project_path: Path, log_path: Optional[str]) -> CommandResult:
+    project_path = _ensure_project_path(project_path)
+    if _is_offline_mode():
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": "Unity connection is not available in offline mode", "code": "unity_compile_unavailable"}],
+        )
+    _clear_console()
+    try:
+        response = send_command_with_retry(
+            "unity_compile",
+            {"projectPath": str(project_path), "logPath": log_path} if log_path else {"projectPath": str(project_path)},
+        )
+    except Exception as exc:
+        logger.error("unity_compile failed: %s", exc)
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": str(exc), "code": "unity_compile_failed"}],
+        )
+    bridge = _normalize_bridge_response(response, default_error_code="unity_compile_failed")
+    if not bridge.ok:
+        return bridge
+
+    logs = _collect_console_entries(types=["error", "warning"])
+    errors = [entry for entry in logs if entry.get("type") == "error"]
+    warnings = [entry for entry in logs if entry.get("type") == "warning"]
+    parsed_errors = [_parse_console_diagnostic(entry, project_path) for entry in errors]
+    parsed_warnings = [_parse_console_diagnostic(entry, project_path) for entry in warnings]
+    parsed_errors = [e for e in parsed_errors if e]
+    parsed_warnings = [w for w in parsed_warnings if w]
+
+    ok = not parsed_errors
+    payload = {
+        "errors": parsed_errors,
+        "warnings": parsed_warnings,
+        "rawLogPath": bridge.data.get("logPath") if bridge.data else None,
+    }
+    return CommandResult(ok=ok, exit_code=0 if ok else 1, data=payload, errors=parsed_errors if not ok else None)
+
+
+def _unity_run_tests_impl(project_path: Path, platform: str, results_path: Optional[str]) -> CommandResult:
+    project_path = _ensure_project_path(project_path)
+    if _is_offline_mode():
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": "Unity connection is not available in offline mode", "code": "unity_tests_unavailable"}],
+        )
+    _clear_console()
+    try:
+        response = send_command_with_retry(
+            "unity_run_tests",
+            {
+                "projectPath": str(project_path),
+                "platform": platform,
+                "resultsPath": results_path,
+            },
+        )
+    except Exception as exc:
+        logger.error("unity_run_tests failed: %s", exc)
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": str(exc), "code": "unity_run_tests_failed"}],
+        )
+    bridge = _normalize_bridge_response(response, default_error_code="unity_run_tests_failed")
+    if not bridge.ok:
+        return bridge
+
+    data = bridge.data or {}
+    results_file = data.get("resultsPath")
+    if not results_file:
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": "Unity did not return a resultsPath", "code": "TEST_RESULTS_MISSING"}],
+        )
+
+    summary = _parse_nunit_results(Path(results_file))
+    if summary is None:
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": f"Unable to parse NUnit results at {results_file}", "code": "TEST_RESULTS_PARSE"}],
+        )
+
+    ok = summary["failed"] == 0
+    payload = {
+        "passed": summary["passed"],
+        "failed": summary["failed"],
+        "durationSec": summary["duration"],
+        "failures": summary["failures"],
+        "resultsPath": results_file,
+        "logPath": data.get("logPath"),
+    }
+    errors = [
+        {
+            "message": failure["message"],
+            "file": failure.get("file"),
+            "line": failure.get("line"),
+        }
+        for failure in summary["failures"]
+    ] if not ok else None
+    return CommandResult(ok=ok, exit_code=0 if ok else 1, data=payload, errors=errors)
+
+
+def _unity_build_il2cpp_impl(project_path: Path, target: str, output_dir: Optional[str]) -> CommandResult:
+    project_path = _ensure_project_path(project_path)
+    if _is_offline_mode():
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": "Unity connection is not available in offline mode", "code": "unity_build_il2cpp_unavailable"}],
+        )
+    try:
+        response = send_command_with_retry(
+            "unity_build_il2cpp",
+            {"projectPath": str(project_path), "target": target, "outputDir": output_dir},
+        )
+    except Exception as exc:
+        logger.error("unity_build_il2cpp failed: %s", exc)
+        return CommandResult(
+            ok=False,
+            exit_code=1,
+            errors=[{"message": str(exc), "code": "unity_build_il2cpp_failed"}],
+        )
+    bridge = _normalize_bridge_response(response, default_error_code="unity_build_il2cpp_failed")
+    if bridge.ok:
+        return bridge
+    return CommandResult(
+        ok=False,
+        exit_code=bridge.exit_code or 1,
+        errors=bridge.errors or [{"message": "IL2CPP build failed"}],
+    )
+
+
+def _ensure_project_path(project_path: Path) -> Path:
+    if not project_path.exists():
+        raise FileNotFoundError(f"Project path does not exist: {project_path}")
+    return project_path.resolve()
+
+
+def _normalize_bridge_response(response: Dict[str, Any], default_error_code: str) -> CommandResult:
+    if isinstance(response, dict) and response.get("success"):
+        data = response.get("data") or {}
+        return CommandResult(ok=True, exit_code=0, data=data)
+
+    error_message = "Unknown Unity error"
+    code = default_error_code
+    if isinstance(response, dict):
+        error_message = response.get("message") or response.get("error") or error_message
+        code = response.get("code") or code
+    return CommandResult(ok=False, exit_code=1, errors=[{"message": error_message, "code": code}])
+
+
+def _gather_reference_assemblies(project_path: Path, probe_data: Dict[str, Any]) -> List[str]:
+    paths = []
+    search_paths = probe_data.get("managedAssemblySearchPaths") or []
+    for entry in search_paths:
+        if entry and Path(entry).exists():
+            paths.append(Path(entry))
+
+    library_script_assemblies = project_path / "Library" / "ScriptAssemblies"
+    if library_script_assemblies.exists():
+        paths.append(library_script_assemblies)
+
+    references: List[str] = []
+    preferred = [
+        "netstandard.dll",
+        "mscorlib.dll",
+        "System.dll",
+        "System.Core.dll",
+        "UnityEngine.dll",
+        "UnityEditor.dll",
+        "UnityEngine.CoreModule.dll",
+        "UnityEditor.CoreModule.dll",
+        "UnityEngine.UI.dll",
+    ]
+
+    for directory in paths:
+        for name in preferred:
+            candidate = directory / name
+            if candidate.exists():
+                references.append(str(candidate))
+
+        # Also include all assemblies in ScriptAssemblies for dependencies (e.g., generated asmdefs)
+        if directory == library_script_assemblies:
+            for assembly in directory.glob("*.dll"):
+                references.append(str(assembly))
+
+    return sorted(set(references))
+
+
+def _parse_csc_output(stdout: str, stderr: str, base_path: Path) -> List[Dict[str, Any]]:
+    diagnostics: List[Dict[str, Any]] = []
+    for line in (stdout.splitlines() + stderr.splitlines()):
+        match = _CSC_ERROR_RE.match(line.strip())
+        if not match:
+            continue
+        if match.group("kind") != "error":
+            continue
+        file_path = match.group("file")
+        abs_path = Path(file_path)
+        if not abs_path.is_absolute():
+            abs_path = (base_path / file_path).resolve()
+        try:
+            rel_path = abs_path.relative_to(base_path)
+        except ValueError:
+            rel_path = abs_path
+        diagnostics.append(
+            {
+                "code": match.group("code"),
+                "file": str(rel_path).replace(os.sep, "/"),
+                "line": int(match.group("line")),
+                "message": match.group("message").strip(),
+            }
+        )
+    return diagnostics
+
+
+def _clear_console() -> None:
+    try:
+        send_command_with_retry("read_console", {"action": "clear"})
+    except Exception:
+        logger.debug("Failed to clear Unity console before operation", exc_info=True)
+
+
+def _collect_console_entries(types: List[str]) -> List[Dict[str, Any]]:
+    try:
+        response = send_command_with_retry(
+            "read_console",
+            {
+                "action": "get",
+                "types": types,
+                "format": "json",
+                "includeStacktrace": True,
+            },
+        )
+    except Exception as exc:
+        logger.error("Failed to collect console entries: %s", exc)
+        return []
+
+    if not isinstance(response, dict) or not response.get("success"):
+        return []
+    return response.get("data", {}).get("lines", []) or []
+
+
+def _parse_console_diagnostic(entry: Dict[str, Any], project_path: Path) -> Optional[Dict[str, Any]]:
+    message = entry.get("message") or entry.get("content")
+    if not message:
+        return None
+
+    match = _CSC_ERROR_RE.match(message.splitlines()[0].strip())
+    if match:
+        file_path = match.group("file")
+        line = int(match.group("line"))
+        return {
+            "code": match.group("code"),
+            "file": _relative_path(project_path, file_path),
+            "line": line,
+            "message": match.group("message").strip(),
+        }
+
+    return {
+        "message": message.strip(),
+        "type": entry.get("type"),
+    }
+
+
+def _relative_path(base: Path, path_str: str) -> str:
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = (base / path).resolve()
+    try:
+        rel = path.relative_to(base)
+        return str(rel).replace(os.sep, "/")
+    except ValueError:
+        return str(path)
+
+
+def _parse_nunit_results(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        tree = ElementTree.parse(path)
+    except ElementTree.ParseError:
+        return None
+
+    root = tree.getroot()
+    if root.tag != "test-run":
+        return None
+
+    def _int_attr(node: ElementTree.Element, name: str) -> int:
+        value = node.get(name)
+        try:
+            return int(float(value)) if value is not None else 0
+        except ValueError:
+            return 0
+
+    passed = _int_attr(root, "passed")
+    failed = _int_attr(root, "failed")
+    duration_str = root.get("duration") or "0"
+    try:
+        duration = float(duration_str)
+    except ValueError:
+        duration = 0.0
+
+    failures: List[Dict[str, Any]] = []
+    for case in root.iter("test-case"):
+        result = case.get("result") or ""
+        if result.lower() != "failed":
+            continue
+        failure_node = case.find("failure")
+        message = ""
+        stack = ""
+        if failure_node is not None:
+            message_node = failure_node.find("message")
+            stack_node = failure_node.find("stack-trace")
+            message = message_node.text if message_node is not None and message_node.text else ""
+            stack = stack_node.text if stack_node is not None and stack_node.text else ""
+        failures.append(
+            {
+                "testName": case.get("fullname") or case.get("name"),
+                "message": message.strip(),
+                "stacktrace": stack.strip(),
+            }
+        )
+
+    return {
+        "passed": passed,
+        "failed": failed,
+        "duration": duration,
+        "failures": failures,
+    }
+
+
+def _offline_project_probe(project_path: Path) -> Dict[str, Any]:
+    version = "unknown"
+    version_file = project_path / "ProjectSettings" / "ProjectVersion.txt"
+    if version_file.exists():
+        for line in version_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if "m_EditorVersion" in line:
+                version = line.split(":", 1)[-1].strip()
+                break
+
+    api_level = "Unknown"
+    scripting_backends: Dict[str, str] = {}
+    settings_file = project_path / "ProjectSettings" / "ProjectSettings.asset"
+    api_map = {
+        "1": "NET_2_0_Subset",
+        "2": "NET_2_0",
+        "3": "NET_4_6",
+        "6": "NET_Standard_2_0",
+        "8": "NET_Standard_2_1",
+    }
+    backend_map = {
+        "0": "Mono",
+        "1": "IL2CPP",
+        "2": "WinRTDotNET",
+    }
+
+    if settings_file.exists():
+        text = settings_file.read_text(encoding="utf-8", errors="ignore")
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("apiCompatibilityLevel:") and "Standalone" in line:
+                value = line.split("Standalone", 1)[-1].strip().strip('{}[]:, ')
+                api_level = api_map.get(value, value or api_level)
+            if line.startswith("scriptingBackend:") and "Standalone" in line:
+                value = line.split("Standalone", 1)[-1].strip().strip('{}[]:, ')
+                scripting_backends["Standalone"] = backend_map.get(value, value)
+
+    packages = []
+    packages_lock = project_path / "Packages" / "packages-lock.json"
+    if packages_lock.exists():
+        try:
+            data = json.loads(packages_lock.read_text(encoding="utf-8"))
+            for name, meta in (data.get("dependencies") or {}).items():
+                packages.append({"name": name, "version": meta.get("version", "")})
+        except Exception:
+            pass
+
+    roslyn_path = os.environ.get("UNITY_CSC_PATH", "")
+
+    return {
+        "unityVersion": version,
+        "apiCompatibilityLevel": api_level,
+        "scriptingBackendPerPlatform": scripting_backends,
+        "packages": packages,
+        "editorApplicationPath": "",
+        "roslynCompilerPath": roslyn_path,
+        "managedAssemblySearchPaths": [],
+    }

--- a/scripts/try_pipeline.sh
+++ b/scripts/try_pipeline.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_SRC="$(cd "$SCRIPT_DIR/../UnityMcpBridge/UnityMcpServer~/src" && pwd)"
+
+PROJECT_PATH="${1:-$(pwd)}"
+LOG_DIR="${2:-$PROJECT_PATH/logs}"
+
+# Ensure required Python dependencies are available.
+if ! python -c "import mcp" >/dev/null 2>&1; then
+  echo "[try_pipeline] Missing required Python dependency 'mcp'. Please install UnityMcpBridge/UnityMcpServer~/src first." >&2
+  exit 1
+fi
+
+PYTHONPATH="$SERVER_SRC${PYTHONPATH:+:$PYTHONPATH}" python -m tools.pipeline_runner --project "$PROJECT_PATH" --log-dir "$LOG_DIR"

--- a/validation.json
+++ b/validation.json
@@ -1,0 +1,5 @@
+{
+  "compile": {"maxErrors": 0},
+  "tests": {"editMinPassRate": 0.95, "playMinPassRate": 0.90},
+  "il2cpp": {"required": false}
+}


### PR DESCRIPTION
## Summary
- expose new MCP automation tools for Unity project probing, Roslyn dry-compilation, editor compilation, tests, and IL2CPP stubs with offline fallbacks
- add bridge-side automation entry points plus documentation, validation config, and a local pipeline runner script
- register the new tools, update dependencies, and wire a CI workflow that exercises the pipeline and uploads logs
- fix Unity automation test execution dispatch and ensure the local pipeline runner exits non-zero when any step fails

## Testing
- `python -m compileall UnityMcpBridge/UnityMcpServer~/src/tools`


------
https://chatgpt.com/codex/tasks/task_e_68d0c311959c832799a17dd907687167